### PR TITLE
refactor: replace deprecated __proto__ in built-in Error example

### DIFF
--- a/sections/errorhandling/useonlythebuiltinerror.brazilian-portuguese.md
+++ b/sections/errorhandling/useonlythebuiltinerror.brazilian-portuguese.md
@@ -47,7 +47,8 @@ function AppError(name, httpCode, description, isOperational) {
     //...outras propriedades atribuídas aqui
 };
 
-AppError.prototype.__proto__ = Error.prototype;
+AppError.prototype = Object.create(Error.prototype);
+AppError.prototype.constructor = AppError;
 
 module.exports.AppError = AppError;
 

--- a/sections/errorhandling/useonlythebuiltinerror.chinese.md
+++ b/sections/errorhandling/useonlythebuiltinerror.chinese.md
@@ -12,11 +12,11 @@ JS天生的宽容性及其多变的代码流选项（例如 EventEmitter, Callba
 //从典型函数抛出错误, 无论是同步还是异步
 if(!productToAdd)
     throw new Error("How can I add new product when no value provided?");
- 
+
 //从EventEmitter抛出错误
 const myEmitter = new MyEmitter();
 myEmitter.emit('error', new Error('whoops!'));
- 
+
 //从promise抛出错误
  return new promise(function (resolve, reject) {
     Return DAL.getProduct(productToAdd.id).then((existingProduct) => {
@@ -45,10 +45,11 @@ function appError(name, httpCode, description, isOperational) {
     //...在这赋值其它属性
 };
 
-appError.prototype.__proto__ = Error.prototype;
+appError.prototype = Object.create(Error.prototype);
+appError.prototype.constructor = appError;
 
 module.exports.appError = appError;
- 
+
 //客户端抛出一个错误
 if(user == null)
   throw new appError(commonErrors.resourceNotFound, commonHTTPErrors.notFound, "further explanation", true)
@@ -63,17 +64,17 @@ if(user == null)
 ### 博客引用: "字符串不是错误"
 
 摘自博客 devthought.com, 对于关键字 “Node.JS error object” 排名第6
- 
+
 > … 传递字符串而不是错误会导致模块间协作性降低。它打破了和API的约定，可能在执行`instanceof`这样的错误检查，或想了解更多关于错误的信息。正如我们将看到的，错误对象在现代JavaScript引擎中拥有非常有趣的属性，同时保留传递给构造函数的消息…
- 
+
 ### 博客引用: "从Error对象继承不会增加太多的价值"
 
 摘自博客 machadogj
- 
+
 > … 我对Error类的一个问题是不太容易扩展。当然, 您可以继承该类并创建自己的Error类, 如HttpError、DbError等。然而, 这需要时间, 并且不会增加太多的价值, 除非你是在做一些关于类型的事情。有时, 您只想添加一条消息, 并保留内部错误, 有时您可能希望使用参数扩展该错误, 等等…
 
 ### 博客引用: "Node.js引发的所有JavaScript和系统错误都继承自Error"
 
 摘自 Node.JS 官方文档
- 
+
 > … Node.js引发的所有JavaScript和系统错误继承自，或是JavaScript标准错误类的实例, 这保证至少提供了该类的可用属性。一个通用的JavaScript错误对象, 它不表示错误为什么发生的任何特定环境。错误对象捕获一个"stack trace", 详细说明了错误被实例化时在代码中的点, 并可能提供错误的文本描述。由Node.js生成的所有错误, 包括所有的系统和JavaScript错误, 都将是Error类的实例, 或继承自Error类 …

--- a/sections/errorhandling/useonlythebuiltinerror.korean.md
+++ b/sections/errorhandling/useonlythebuiltinerror.korean.md
@@ -47,7 +47,8 @@ function AppError(name, httpCode, description, isOperational) {
     //...other properties assigned here
 };
 
-AppError.prototype.__proto__ = Error.prototype;
+AppError.prototype = Object.create(Error.prototype);
+AppError.prototype.constructor = AppError;
 
 module.exports.AppError = AppError;
 

--- a/sections/errorhandling/useonlythebuiltinerror.md
+++ b/sections/errorhandling/useonlythebuiltinerror.md
@@ -50,7 +50,8 @@ function AppError(name, httpCode, description, isOperational) {
     //...other properties assigned here
 };
 
-AppError.prototype.__proto__ = Error.prototype;
+AppError.prototype = Object.create(Error.prototype);
+AppError.prototype.constructor = AppError;
 
 module.exports.AppError = AppError;
 

--- a/sections/errorhandling/useonlythebuiltinerror.russian.md
+++ b/sections/errorhandling/useonlythebuiltinerror.russian.md
@@ -47,7 +47,8 @@ function AppError(name, httpCode, description, isOperational) {
     //...other properties assigned here
 };
 
-AppError.prototype.__proto__ = Error.prototype;
+AppError.prototype = Object.create(Error.prototype);
+AppError.prototype.constructor = AppError;
 
 module.exports.AppError = AppError;
 


### PR DESCRIPTION
[`__proto__`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto) is deprecated and shouldn't be used to set object prototype.