### PR TITLE
docs: Add a section about using npm ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Read in a different language: [![CN](/assets/flags/CN.png)**CN**](/README.chines
 2. [Error Handling Practices (11) ](#2-error-handling-practices)
 3. [Code Style Practices (12) ](#3-code-style-practices)
 4. [Testing And Overall Quality Practices (12) ](#4-testing-and-overall-quality-practices)
-5. [Going To Production Practices (18) ](#5-going-to-production-practices)
+5. [Going To Production Practices (19) ](#5-going-to-production-practices)
 6. [Security Practices (25)](#6-security-best-practices)
 7. [Performance Practices (2) (Work In Progress️ ✍️)](#7-draft-performance-best-practices)
 
@@ -719,6 +719,16 @@ All statements above will return false if used with `===`
 **Otherwise:** Application handling log routing === hard to scale, loss of logs, poor separation of concerns
 
 🔗 [**Read More: Log Routing**](/sections/production/logrouting.md)
+
+<br/><br/>
+
+## ![✔] 5.19. Install your packages with `npm ci`
+
+**TL;DR:** You have to be sure that production code uses the exact version of the packages you have tested it with. Run `npm ci` to do a clean install of your dependencies matching package.json and package-lock.json.
+
+**Otherwise:** QA will thoroughly test the code and approve a version that will behave differently in production. Even worse, different servers in the same production cluster might run different code
+
+🔗 [**Read More: Use npm ci**](/sections/production/installpackageswithnpmci.md)
 
 <br/><br/><br/>
 

--- a/sections/production/installpackageswithnpmci.md
+++ b/sections/production/installpackageswithnpmci.md
@@ -1,0 +1,30 @@
+# Install packages with npm ci in production
+
+<br/><br/>
+
+### One Paragraph Explainer
+
+You locked your dependencies following [**Lock dependencies**](/sections/production/lockdependencies.md) but you now need to make sure those exact package versions are used in production.
+
+Using `npm ci` to install packages will do exactly that and more.
+* It will fail if your `package.json` and your `package-lock.json` do not match (they should) or if you don't have a lock file
+* If a `node_modules` folder is present it will automatically remove it before installing
+* It is faster! Nearly twice as fast according to [the release blog post](https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable)
+
+### When can this be useful?
+You are guaranteed that you CI environment or QA will test your software with exactly the same package version that the one you will later send to production.
+Also, if for some reason someone manually changes package.json, not through a cli command but rather by directly editing package.json, a gap between package.json & package-lock.json is created and an error will be thrown.
+
+### What npm says
+
+From [npm ci documentation](https://docs.npmjs.com/cli/ci.html)
+> This command is similar to npm-install, except it’s meant to be used in automated environments such as test platforms, continuous integration, and deployment – or any situation where you want to make sure you’re doing a clean install of your dependencies.
+
+[Blog post announcing the release of `ci` command](https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable)
+>  The command offers massive improvements to both the performance and reliability of builds for continuous integration / continuous deployment processes, providing a consistent and fast experience for developers using CI/CD in their workflow.
+
+[npmjs: dependencies and devDepencies](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file)
+>    "dependencies": Packages required by your application in production.
+>    "devDependencies": Packages that are only needed for local development and testing.
+
+<br/><br/>


### PR DESCRIPTION
Hi there,

I added a section about the use of npm ci.
I thought it would be better to put it right after the bullet point about locking dependencies.

Let me know what you think of it.