### PR TITLE
Remove unmaintained loggers and recommend pino first

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Read in a different language: [![CN](/assets/flags/CN.png)**CN**](/README.chines
 
 ## ![✔] 2.7 Use a mature logger to increase error visibility
 
-**TL;DR:** A set of mature logging tools like [Winston](https://www.npmjs.com/package/winston), [Bunyan](https://github.com/trentm/node-bunyan), [Log4js](http://stritti.github.io/log4js/) or [Pino](https://github.com/pinojs/pino), will speed-up error discovery and understanding. So forget about console.log
+**TL;DR:** A set of mature logging tools like [Pino](https://github.com/pinojs/pino) or [Log4js](https://www.npmjs.com/package/log4js), will speed-up error discovery and understanding. So forget about console.log
 
 **Otherwise:** Skimming through console.logs or manually through messy text file without querying tools or a decent log viewer might keep you busy at work until late
 


### PR DESCRIPTION
Hey, it doesn't look like winston and bunyan are particularly updated. Bunyan hasn't been updated in ~3 years for example.

The list should also mention somewhere that it's important to log to stdout and persist with another process.

CC @goldbergyoni 