### PR TITLE
Use npm ci command in Docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1085,7 +1085,7 @@ Bear in mind that with the introduction of the new V8 engine alongside the new E
 
 ## ![✔] 8.1 Use multi-stage builds for leaner and more secure Docker images
 
-**TL;DR:** Use multi-stage build to copy only necessary production artifacts. A lot of build-time dependencies and files are not needed for running your application. With multi-stage builds these resources can be used during build while the runtime environment contains only what's necessary. Multi-stage builds are an easy way to get rid of overweight and security threats
+**TL;DR:** Use multi-stage build to copy only necessary production artifacts. A lot of build-time dependencies and files are not needed for running your application. With multi-stage builds these resources can be used during build while the runtime environment contains only what's necessary. Multi-stage builds are an easy way to get rid of overweight and security threats. Since Docker is often used in continous integration environments it is recommended to use the `npm ci` command (instead of `npm install`). It is faster, stricter and reduces inconsistencies by using only the versions specified in the package-lock.json file. See [here](https://docs.npmjs.com/cli/ci.html#description) for more info.
 
 **Otherwise:** Larger images will take longer to build and ship, build-only tools might contain vulnerabilities and secrets only meant for the build phase might be leaked.
 
@@ -1095,7 +1095,7 @@ Bear in mind that with the introduction of the new V8 engine alongside the new E
 FROM node:14.4.0 AS build
 
 COPY . .
-RUN npm install && npm run build
+RUN npm ci && npm run build
 
 FROM node:slim-14.4.0
 
@@ -1103,7 +1103,7 @@ USER node
 EXPOSE 8080
 
 COPY --from=build /home/node/app/dist /home/node/app/package.json /home/node/app/package-lock.json ./
-RUN npm install --production
+RUN npm ci --production
 
 CMD [ "node", "dist/app.js" ]
 ```

--- a/README.md
+++ b/README.md
@@ -1085,7 +1085,7 @@ Bear in mind that with the introduction of the new V8 engine alongside the new E
 
 ## ![✔] 8.1 Use multi-stage builds for leaner and more secure Docker images
 
-**TL;DR:** Use multi-stage build to copy only necessary production artifacts. A lot of build-time dependencies and files are not needed for running your application. With multi-stage builds these resources can be used during build while the runtime environment contains only what's necessary. Multi-stage builds are an easy way to get rid of overweight and security threats. Since Docker is often used in continuous integration environments it is recommended to use the `npm ci` command (instead of `npm install`). It is faster, stricter and reduces inconsistencies by using only the versions specified in the package-lock.json file. See [here](https://docs.npmjs.com/cli/ci.html#description) for more info.
+**TL;DR:** Use multi-stage build to copy only necessary production artifacts. A lot of build-time dependencies and files are not needed for running your application. With multi-stage builds these resources can be used during build while the runtime environment contains only what's necessary. Multi-stage builds are an easy way to get rid of overweight and security threats.
 
 **Otherwise:** Larger images will take longer to build and ship, build-only tools might contain vulnerabilities and secrets only meant for the build phase might be leaked.
 

--- a/README.md
+++ b/README.md
@@ -736,9 +736,9 @@ All statements above will return false if used with `===`
 
 ## ![✔] 5.19. Install your packages with `npm ci` 
 
-**TL;DR:** You have to be sure that production code uses the exact version of the packages you have tested it with. Run `npm ci` to do a clean install of your dependencies matching package.json and package-lock.json. Using this command is recommended in automated environments such as continuous integration pipelines. It is stricter by throwing an error if the versions in package.json and package-lock.json do not match. Since it can be significantly faster than `npm install`, it can also save you CI pipeline minutes. See [here](https://docs.npmjs.com/cli/ci.html#description) for more info.
+**TL;DR:** You have to be sure that production code uses the exact version of the packages you have tested it with. Run `npm ci` to strictly do a clean install of your dependencies matching package.json and package-lock.json. Using this command is recommended in automated environments such as continuous integration pipelines.
 
-**Otherwise:****** QA will thoroughly test the code and approve a version that will behave differently in production. Even worse, different servers in the same production cluster might run different code
+**Otherwise:** QA will thoroughly test the code and approve a version that will behave differently in production. Even worse, different servers in the same production cluster might run different code.
 
 🔗 [**Read More: Use npm ci**](/sections/production/installpackageswithnpmci.md)
 

--- a/README.md
+++ b/README.md
@@ -734,9 +734,9 @@ All statements above will return false if used with `===`
 
 <br/><br/>
 
-## ![✔] 5.19. Install your packages with `npm ci`
+## ![✔] 5.19. Install your packages with `npm ci` 
 
-**TL;DR:** You have to be sure that production code uses the exact version of the packages you have tested it with. Run `npm ci` to do a clean install of your dependencies matching package.json and package-lock.json.
+**TL;DR:** You have to be sure that production code uses the exact version of the packages you have tested it with. Run `npm ci` to do a clean install of your dependencies matching package.json and package-lock.json. Using this command is recommended in automated environments such as continuous integration pipelines. It is stricter by throwing an error if the versions in package.json and package-lock.json do not match. Since it can be significantly faster than `npm install`, it can also save you CI pipeline minutes. See [here](https://docs.npmjs.com/cli/ci.html#description) for more info.
 
 **Otherwise:****** QA will thoroughly test the code and approve a version that will behave differently in production. Even worse, different servers in the same production cluster might run different code
 
@@ -1085,7 +1085,7 @@ Bear in mind that with the introduction of the new V8 engine alongside the new E
 
 ## ![✔] 8.1 Use multi-stage builds for leaner and more secure Docker images
 
-**TL;DR:** Use multi-stage build to copy only necessary production artifacts. A lot of build-time dependencies and files are not needed for running your application. With multi-stage builds these resources can be used during build while the runtime environment contains only what's necessary. Multi-stage builds are an easy way to get rid of overweight and security threats. Since Docker is often used in continous integration environments it is recommended to use the `npm ci` command (instead of `npm install`). It is faster, stricter and reduces inconsistencies by using only the versions specified in the package-lock.json file. See [here](https://docs.npmjs.com/cli/ci.html#description) for more info.
+**TL;DR:** Use multi-stage build to copy only necessary production artifacts. A lot of build-time dependencies and files are not needed for running your application. With multi-stage builds these resources can be used during build while the runtime environment contains only what's necessary. Multi-stage builds are an easy way to get rid of overweight and security threats. Since Docker is often used in continuous integration environments it is recommended to use the `npm ci` command (instead of `npm install`). It is faster, stricter and reduces inconsistencies by using only the versions specified in the package-lock.json file. See [here](https://docs.npmjs.com/cli/ci.html#description) for more info.
 
 **Otherwise:** Larger images will take longer to build and ship, build-only tools might contain vulnerabilities and secrets only meant for the build phase might be leaked.
 

--- a/sections/docker/multi_stage_builds.md
+++ b/sections/docker/multi_stage_builds.md
@@ -31,11 +31,13 @@ docs
 
 #### Dockerfile with multiple stages
 
+Since Docker is often used in continuous integration environments it is recommended to use the `npm ci` command (instead of `npm install`). It is faster, stricter and reduces inconsistencies by using only the versions specified in the package-lock.json file. See [here](https://docs.npmjs.com/cli/ci.html#description) for more info. This example uses yarn as package manager for which the equivalent to `npm ci` is the `yarn install --frozen-lockfile` [command](https://classic.yarnpkg.com/en/docs/cli/install/).
+
 ```dockerfile
 FROM node:14.4.0 AS build
 
 COPY --chown=node:node . .
-RUN yarn install && yarn build
+RUN yarn install --frozen-lockfile && yarn build
 
 FROM node:14.4.0
 
@@ -44,7 +46,7 @@ EXPOSE 8080
 
 # Copy results from previous stage
 COPY --chown=node:node --from=build /home/node/app/dist /home/node/app/package.json /home/node/app/yarn.lock ./
-RUN yarn install --production
+RUN yarn install --frozen-lockfile --production
 
 CMD [ "node", "dist/app.js" ]
 ```
@@ -55,7 +57,7 @@ CMD [ "node", "dist/app.js" ]
 FROM node:14.4.0 AS build
 
 COPY --chown=node:node . .
-RUN yarn install && yarn build
+RUN yarn install --frozen-lockfile && yarn build
 
 # This will use a minimal base image for the runtime
 FROM node:14.4.0-alpine
@@ -65,7 +67,7 @@ EXPOSE 8080
 
 # Copy results from previous stage
 COPY --chown=node:node --from=build /home/node/app/dist /home/node/app/package.json /home/node/app/yarn.lock ./
-RUN yarn install --production
+RUN yarn install --frozen-lockfile --production
 
 CMD [ "node", "dist/app.js" ]
 ```


### PR DESCRIPTION
Also added the hint in chapter 5.19 to use the `npm ci` command in automated environments.

Maybe this should also be updated in the *in detail section* [Multi Stage Builds with Docker](https://github.com/goldbergyoni/nodebestpractices/blob/master/sections/docker/multi_stage_builds.md), but this example uses yarn, which would be `yarn install --frozen-lockfile` then. Ideally with a short explanation that both commands can be fine, depending which package manager you use.