### PR TITLE
Refer to OpenAPI

### DIFF
--- a/sections/errorhandling/documentingusingswagger.md
+++ b/sections/errorhandling/documentingusingswagger.md
@@ -1,4 +1,4 @@
-# Document API errors using OpenAPI Specification (earliar known as Swagger) or GraphQL
+# Document API errors using OpenAPI Specification (earlier known as Swagger) or GraphQL
 
 ### One Paragraph Explainer
 

--- a/sections/errorhandling/documentingusingswagger.md
+++ b/sections/errorhandling/documentingusingswagger.md
@@ -1,8 +1,8 @@
-# Document API errors using Swagger or GraphQL
+# Document API errors using OpenAPI Specification (eka Swagger) or GraphQL
 
 ### One Paragraph Explainer
 
-REST APIs return results using HTTP status codes, it’s absolutely required for the API user to be aware not only about the API schema but also about potential errors – the caller may then catch an error and tactfully handle it. For example, your API documentation might state in advance that HTTP status 409 is returned when the customer name already exists (assuming the API register new users) so the caller can correspondingly render the best UX for the given situation. Swagger is a standard that defines the schema of API documentation offering an eco-system of tools that allow creating documentation easily online, see print screens below
+REST APIs return results using HTTP status codes, it’s absolutely required for the API user to be aware not only about the API schema but also about potential errors – the caller may then catch an error and tactfully handle it. For example, your API documentation might state in advance that HTTP status 409 is returned when the customer name already exists (assuming the API register new users) so the caller can correspondingly render the best UX for the given situation. OpenAPI (eka Swagger) is a standard that defines the schema of API documentation offering an eco-system of tools that allow creating documentation easily online, see print screens below
 
 If you have already adopted GraphQL for your API endpoints, your schema already contains strict guarantees as to what errors should look like ([outlined in the spec](https://facebook.github.io/graphql/June2018/#sec-Errors)) and how they should be handled by your client-side tooling. In addition, you can also supplement them with comment-based documentation.
 

--- a/sections/errorhandling/documentingusingswagger.md
+++ b/sections/errorhandling/documentingusingswagger.md
@@ -1,4 +1,4 @@
-# Document API errors using OpenAPI Specification (eka Swagger) or GraphQL
+# Document API errors using OpenAPI Specification (earliar known as Swagger) or GraphQL
 
 ### One Paragraph Explainer
 


### PR DESCRIPTION
Refer to OpenAPI instead of the earlier name of Swagger