### PR TITLE
Add Winston logger to 2.7 (loggers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Read in a different language: [![CN](/assets/flags/CN.png)**CN**](/README.chines
 
 ## ![✔] 2.7 Use a mature logger to increase error visibility
 
-**TL;DR:** A set of mature logging tools like [Pino](https://github.com/pinojs/pino) or [Log4js](https://www.npmjs.com/package/log4js), will speed-up error discovery and understanding. So forget about console.log
+**TL;DR:** A set of mature logging tools like [Winston](https://github.com/winstonjs/winston), [Pino](https://github.com/pinojs/pino) or [Log4js](https://www.npmjs.com/package/log4js), will speed-up error discovery and understanding. So forget about console.log
 
 **Otherwise:** Skimming through console.logs or manually through messy text file without querying tools or a decent log viewer might keep you busy at work until late
 


### PR DESCRIPTION
Adding Winston as a top option under 2.7 loggers.  Reference https://www.npmtrends.com/winston-vs-pino-vs-bole-vs-log4js