### PR TITLE
docs(install-for-production): fix npm cache cli example

### DIFF
--- a/sections/docker/install-for-production.md
+++ b/sections/docker/install-for-production.md
@@ -18,7 +18,7 @@ Dev dependencies greatly increase the container attack surface (i.e. potential s
 FROM node:12-slim AS build
 WORKDIR /usr/src/app
 COPY package.json package-lock.json ./
-RUN npm ci --production && npm clean cache --force
+RUN npm ci --production && npm cache clean --force
 
 # The rest comes here
 ```


### PR DESCRIPTION
See https://docs.npmjs.com/cli/v6/commands/npm-cache, there is no command called `npm clean`