### PR TITLE
fix: typo in the docs

### DIFF
--- a/sections/errorhandling/centralizedhandling.md
+++ b/sections/errorhandling/centralizedhandling.md
@@ -104,7 +104,7 @@ function errorHandler() {
 
 ```typescript
 class ErrorHandler {
-  public async handleError(err: Error, responseStream: Response): Promise<void> {
+  public async handleError(error: Error, responseStream: Response): Promise<void> {
     await logger.logError(error);
     await fireMonitoringMetric(error);
     await crashIfUntrustedErrorOrSendResponse(error, responseStream);      


### PR DESCRIPTION
Fixing a typo in `centralizedhandling.md`