### PR TITLE
Update test example to follow the AAA rule

### DIFF
--- a/sections/testingandquality/avoid-global-test-fixture.md
+++ b/sections/testingandquality/avoid-global-test-fixture.md
@@ -11,13 +11,15 @@
 ### Code example: each test acts on its own set of data
 ```javascript
 it('When updating site name, get successful confirmation', async () => {
-  //test is adding a fresh new records and acting on the records only
+  //Arrange - test is adding a fresh new records and acting on the records only
   const siteUnderTest = await SiteService.addSite({
     name: 'siteForUpdateTest'
   });
 
+  //Act
   const updateNameResult = await SiteService.changeName(siteUnderTest, 'newName');
 
+  //Assert
   expect(updateNameResult).to.be(true);
 });
 ```
@@ -27,23 +29,26 @@ it('When updating site name, get successful confirmation', async () => {
 ### Code Example – Anti Pattern:  tests are not independent and assume the existence of some pre-configured data
 ```javascript
 before(() => {
-  //adding sites and admins data to our DB. Where is the data? outside. At some external json or migration framework
+  //Arrange - adding sites and admins data to our DB. Where is the data? outside. At some external json or migration framework
   await DB.AddSeedDataFromJson('seed.json');
 });
 
 it('When updating site name, get successful confirmation', async () => {
-  //I know that site name 'portal' exists - I saw it in the seed files
+  //Arrange - I know that site name 'portal' exists - I saw it in the seed files
   const siteToUpdate = await SiteService.getSiteByName('Portal');
 
+  //Act
   const updateNameResult = await SiteService.changeName(siteToUpdate, 'newName');
 
+  //Assert
   expect(updateNameResult).to.be(true);
 });
 
 it('When querying by site name, get the right site', async () => {
-  //I know that site name 'portal' exists - I saw it in the seed files
+  //Act - I know that site name 'portal' exists - I saw it in the seed files
   const siteToCheck = await SiteService.getSiteByName('Portal');
 
+  //Assert
   expect(siteToCheck.name).to.be.equal('Portal'); //Failure! The previous test change the name :[
 });
 ```

--- a/sections/testingandquality/avoid-global-test-fixture.md
+++ b/sections/testingandquality/avoid-global-test-fixture.md
@@ -15,7 +15,9 @@ it('When updating site name, get successful confirmation', async () => {
   const siteUnderTest = await SiteService.addSite({
     name: 'siteForUpdateTest'
   });
+
   const updateNameResult = await SiteService.changeName(siteUnderTest, 'newName');
+
   expect(updateNameResult).to.be(true);
 });
 ```
@@ -28,15 +30,20 @@ before(() => {
   //adding sites and admins data to our DB. Where is the data? outside. At some external json or migration framework
   await DB.AddSeedDataFromJson('seed.json');
 });
+
 it('When updating site name, get successful confirmation', async () => {
   //I know that site name 'portal' exists - I saw it in the seed files
   const siteToUpdate = await SiteService.getSiteByName('Portal');
+
   const updateNameResult = await SiteService.changeName(siteToUpdate, 'newName');
+
   expect(updateNameResult).to.be(true);
 });
+
 it('When querying by site name, get the right site', async () => {
   //I know that site name 'portal' exists - I saw it in the seed files
   const siteToCheck = await SiteService.getSiteByName('Portal');
+
   expect(siteToCheck.name).to.be.equal('Portal'); //Failure! The previous test change the name :[
 });
 ```


### PR DESCRIPTION
The test examples have some anti patterns 

> Anti Pattern: no separation, one bulk, harder to interpret
> 
> From [AAA](https://github.com/goldbergyoni/nodebestpractices/blob/master/sections/testingandquality/aaa.md#code-example--anti-pattern-no-separation-one-bulk-harder-to-interpret)


