### PR TITLE
ci: limit update last time updated badge only to the main repo

### DIFF
--- a/.github/workflows/update-date-in-last-update-badge.yml
+++ b/.github/workflows/update-date-in-last-update-badge.yml
@@ -8,6 +8,10 @@ jobs:
   run:
     name: Update the date in last update badge to today
     runs-on: ubuntu-20.04
+
+    # Limit this action to only run on the main repo and not on forks
+    if: github.repository_owner == 'goldbergyoni'
+    
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
when you update the master in your fork it will trigger the update badge action so I limited it to only run on this repo

I tested it by merging this branch to my fork’s master branch
