### PR TITLE
fix curly brace placement typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,8 @@ function someFunction() {
 }
 
 // Avoid
-function someFunction() {
+function someFunction()
+{
   // code block
 }
 ```


### PR DESCRIPTION
The opening curly braces of a code block should not be on the same line for the avoid example 