### PR TITLE
do and avoid for curly braces are same

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,8 @@ function someFunction() {
 }
 
 // Avoid
-function someFunction() {
+function someFunction() 
+{
   // code block
 }
 ```


### PR DESCRIPTION
In the main `README` description about dos and don'ts about curly braces positions. They are same leading to confusion

It is
```javascript
// Do
function someFunction() {
  // code block
}

// Avoid
function someFunction() {
  // code block
}
```

Should have been 

```javascript
// Do
function someFunction() {
  // code block
}

// Avoid
function someFunction() 
{
  // code block
}
```
