### PR TITLE
Fix(update last update badge): close the img tag the created

### DIFF
--- a/.github/workflows/update-last-update-badge.sh
+++ b/.github/workflows/update-last-update-badge.sh
@@ -44,7 +44,7 @@ CURRENT_DATE=`date +"%B %d, %Y"`
 LAST_UPDATE_BADGE_REGEX='<img id="last-update-badge" src="https:\/\/img\.shields\.io\/badge\/[^>]*>'
 
 UPDATED_BADGE_URL="https:\/\/img.shields.io\/badge\/${CALENDAR_EMOJI_ENCODED}$(url_encode " Last update - ${CURRENT_DATE}-green").svg"
-UPDATED_LAST_UPDATE_BADGE="<img id=\"last-update-badge\" src=\"$UPDATED_BADGE_URL\" alt=\"Last update: $CURRENT_DATE\">"
+UPDATED_LAST_UPDATE_BADGE="<img id=\"last-update-badge\" src=\"$UPDATED_BADGE_URL\" alt=\"Last update: $CURRENT_DATE\" />"
 
 
 if ! is_there_last_update_badge "$INPUT_FILE" "$LAST_UPDATE_BADGE_REGEX"; then


### PR DESCRIPTION
This is part of the migration to Docusarus that discussed here - #820, #939

All HTML tags must be closed in MDX (Docusarus uses MDX) so although `<img ..>` is valid in plain HTML is invalid in MDX (same for all void elements e.g `img`, `br`, etc...)