### PR TITLE
SeparateExpress: export app!

### DIFF
--- a/sections/projectstructre/separateexpress.md
+++ b/sections/projectstructre/separateexpress.md
@@ -15,6 +15,8 @@ const app = express();
 app.use(bodyParser.json());
 app.use('/api/events', events.API);
 app.use('/api/forms', forms);
+
+module.exports = app;
 ```
 
 ### Code example: Server network declaration, should reside in /bin/www


### PR DESCRIPTION
Noticed that it was missing, which could be confusing since otherwise the `www` file is creating a new instance of a nothing. 