### PR TITLE
migrate: update the html comments after the contributors list to have new line before them

### DIFF
--- a/README.basque.md
+++ b/README.basque.md
@@ -1573,6 +1573,7 @@ Eskerrik asko proiektu honetan parte hartu duten pertsona zoragarriei!
     <td align="center"><a href="http://libkhadir.fr"><img src="https://avatars.githubusercontent.com/u/45130488?v=4?s=100" width="100px;" alt=""/><br /><sub><b>KHADIR Tayeb</b></sub></a><br /><a href="#content-tkhadir" title="Content">🖋</a></td>
   </tr>
 </table>
+
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
 

--- a/README.indonesian.md
+++ b/README.indonesian.md
@@ -1572,6 +1572,7 @@ Terima kasih kepada orang-orang hebat ini yang telah berkontribusi pada reposito
     <td align="center"><a href="http://libkhadir.fr"><img src="https://avatars.githubusercontent.com/u/45130488?v=4?s=100" width="100px;" alt=""/><br /><sub><b>KHADIR Tayeb</b></sub></a><br /><a href="#content-tkhadir" title="Content">🖋</a></td>
   </tr>
 </table>
+
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
 

--- a/README.japanese.md
+++ b/README.japanese.md
@@ -1563,6 +1563,7 @@ JavaScript とそのエコシステム（React、Node.js、TypeScript、GraphQL�
     <td align="center"><a href="http://libkhadir.fr"><img src="https://avatars.githubusercontent.com/u/45130488?v=4?s=100" width="100px;" alt=""/><br /><sub><b>KHADIR Tayeb</b></sub></a><br /><a href="#content-tkhadir" title="Content">🖋</a></td>
   </tr>
 </table>
+
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
 

--- a/README.korean.md
+++ b/README.korean.md
@@ -1369,6 +1369,7 @@ null == undefined; // true
     <td align="center"><a href="http://libkhadir.fr"><img src="https://avatars.githubusercontent.com/u/45130488?v=4?s=100" width="100px;" alt=""/><br /><sub><b>KHADIR Tayeb</b></sub></a><br /><a href="#content-tkhadir" title="Content">🖋</a></td>
   </tr>
 </table>
+
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
 


### PR DESCRIPTION
Must have newlines before the HTML comments as Docusaurus will fail to build without it.

I assume that when they are right after the HTML the parsing done by Docusaurus thinks these comments are part of the HTML which will try to convert it into a React component which would fail the build as HTML comments in React are unsupported (instead of `<!-- some comment -->` you need to do `{/* comment */}`)