### PR TITLE
migrate: convert dead translation links to original links

### DIFF
--- a/README.brazilian-portuguese.md
+++ b/README.brazilian-portuguese.md
@@ -232,7 +232,7 @@ Leia em diferentes idiomas: [![CN](./assets/flags/CN.png)**CN**](./README.chines
 A ausência dessas informações provavelmente complicariam a compreensão do fluxo que leva ao erro,
 especialmente se a causa do comportamento anormal estiver dentro da função ausente 
 
-<!-- 🔗 [**Leia Mais: retornando promises**](./sections/errorhandling/returningpromises.brazilian-portuguese.md) -->
+🔗 [**Leia Mais: retornando promises**](./sections/errorhandling/returningpromises.md)
 
 <br/><br/><br/>
 
@@ -472,7 +472,7 @@ Todas as declarações acima false se feitas com `===`.
 
 **Caso contrário:** Você não somente passará várias horas do dia para entender o código principal, mas agora também gastará várias horas no que deveria ter sido uma simples parte do dia (testando) esticando seu cérebro. 
 
-<!-- 🔗 [**Leia Mais: Estutura de testes padrão AAA**](./sections/testingandquality/aaa.brazilian-portuguese.md) -->
+🔗 [**Leia Mais: Estutura de testes padrão AAA**](./sections/testingandquality/aaa.md)
 
 <br/><br/>
 
@@ -560,7 +560,7 @@ Todas as declarações acima false se feitas com `===`.
 
 **Caso contrário:** Um bug no 'middleware Express' === um bug em todas ou na maioria das solicitações 
 
-<!-- 🔗 [**Read More: Test middlewares in isolation**](./sections/testingandquality/test-middlewares.brazilian-portuguese.md) -->
+🔗 [**Read More: Test middlewares in isolation**](./sections/testingandquality/test-middlewares.md)
 
 <br/><br/><br/>
 
@@ -752,7 +752,7 @@ Todas as declarações acima false se feitas com `===`.
 
 **Caso contrário:** o QA testará completamente o código e aprovará uma versão que se comportará de maneira diferente em produção. Pior ainda, diferentes servidores no mesmo cluster de produção podem executar códigos diferentes.
 
-<!-- 🔗 [**Read More: Use npm ci**](/sections/production/installpackageswithnpmci.md) -->
+🔗 [**Read More: Use npm ci**](/sections/production/installpackageswithnpmci.md)
 
 <br/><br/><br/>
 

--- a/README.brazilian-portuguese.md
+++ b/README.brazilian-portuguese.md
@@ -752,7 +752,7 @@ Todas as declarações acima false se feitas com `===`.
 
 **Caso contrário:** o QA testará completamente o código e aprovará uma versão que se comportará de maneira diferente em produção. Pior ainda, diferentes servidores no mesmo cluster de produção podem executar códigos diferentes.
 
-🔗 [**Read More: Use npm ci**](/sections/production/installpackageswithnpmci.md)
+🔗 [**Read More: Use npm ci**](./sections/production/installpackageswithnpmci.md)
 
 <br/><br/><br/>
 

--- a/README.brazilian-portuguese.md
+++ b/README.brazilian-portuguese.md
@@ -232,7 +232,7 @@ Leia em diferentes idiomas: [![CN](./assets/flags/CN.png)**CN**](./README.chines
 A ausência dessas informações provavelmente complicariam a compreensão do fluxo que leva ao erro,
 especialmente se a causa do comportamento anormal estiver dentro da função ausente 
 
-<!-- 🔗 [**Leia Mais: retornando promises**](/sections/errorhandling/returningpromises.brazilian-portuguese.md) -->
+<!-- 🔗 [**Leia Mais: retornando promises**](./sections/errorhandling/returningpromises.brazilian-portuguese.md) -->
 
 <br/><br/><br/>
 
@@ -472,7 +472,7 @@ Todas as declarações acima false se feitas com `===`.
 
 **Caso contrário:** Você não somente passará várias horas do dia para entender o código principal, mas agora também gastará várias horas no que deveria ter sido uma simples parte do dia (testando) esticando seu cérebro. 
 
-<!-- 🔗 [**Leia Mais: Estutura de testes padrão AAA**](/sections/testingandquality/aaa.brazilian-portuguese.md) -->
+<!-- 🔗 [**Leia Mais: Estutura de testes padrão AAA**](./sections/testingandquality/aaa.brazilian-portuguese.md) -->
 
 <br/><br/>
 
@@ -560,7 +560,7 @@ Todas as declarações acima false se feitas com `===`.
 
 **Caso contrário:** Um bug no 'middleware Express' === um bug em todas ou na maioria das solicitações 
 
-<!-- 🔗 [**Read More: Test middlewares in isolation**](/sections/testingandquality/test-middlewares.brazilian-portuguese.md) -->
+<!-- 🔗 [**Read More: Test middlewares in isolation**](./sections/testingandquality/test-middlewares.brazilian-portuguese.md) -->
 
 <br/><br/><br/>
 

--- a/sections/drafts/readme-general-toc-1.md
+++ b/sections/drafts/readme-general-toc-1.md
@@ -1,12 +1,12 @@
 <!--- # Node.js Best Practices -->
-<!--- ![Node.js Best Practices](assets/images/banner-2.jpg) -->
+<!--- ![Node.js Best Practices](../../assets/images/banner-2.jpg) -->
 <h1 align="center">
   <img src="../../assets/images/banner-2.jpg" alt="Node.js Best Practices" />
 </h1>
 
 <img src="https://img.shields.io/badge/⚙%20Item%20count%20-%2053%20Best%20practices-blue.svg" alt="53 items"/> <img src="https://img.shields.io/badge/%F0%9F%93%85%20Last%20update%20-%206%20days%20ago-green.svg" alt="Last update: 7 days ago"/> <img src="https://img.shields.io/badge/%E2%9C%94%20Updated%20For%20Version%20-%20Node%208.4-brightgreen.svg" alt="Updated for Node v.8.4"/>
 
-<!--- ![Node.js Best Practices](assets/images/banner-1.png) -->
+<!--- ![Node.js Best Practices](../../assets/images/banner-1.png) -->
 
 # Welcome to Node.js Best Practices
 

--- a/sections/drafts/readme-general-toc-3.md
+++ b/sections/drafts/readme-general-toc-3.md
@@ -1,12 +1,12 @@
 <!--- # Node.js Best Practices -->
-<!--- ![Node.js Best Practices](assets/images/banner-2.jpg) -->
+<!--- ![Node.js Best Practices](../../assets/images/banner-2.jpg) -->
 <h1 align="center">
   <img src="../../assets/images/banner-3.jpg" alt="Node.js Best Practices" />
 </h1>
 
 <img src="https://img.shields.io/badge/⚙%20Item%20count%20-%2053%20Best%20practices-blue.svg" alt="53 items"/> <img src="https://img.shields.io/badge/%F0%9F%93%85%20Last%20update%20-%206%20days%20ago-green.svg" alt="Last update: 7 days ago"/> <img src="https://img.shields.io/badge/%E2%9C%94%20Updated%20For%20Version%20-%20Node%208.4-brightgreen.svg" alt="Updated for Node v.8.4"/>
 
-<!--- ![Node.js Best Practices](assets/images/banner-1.png) -->
+<!--- ![Node.js Best Practices](../../assets/images/banner-1.png) -->
 
 # Welcome to Node.js Best Practices
 

--- a/sections/drafts/readme-general-toc-4.md
+++ b/sections/drafts/readme-general-toc-4.md
@@ -1,12 +1,12 @@
 <!--- # Node.js Best Practices -->
-<!--- ![Node.js Best Practices](assets/images/banner-2.jpg) -->
+<!--- ![Node.js Best Practices](../../assets/images/banner-2.jpg) -->
 <h1 align="center">
   <img src="../../assets/images/banner-4.jpg" alt="Node.js Best Practices" />
 </h1>
 
 <img src="https://img.shields.io/badge/⚙%20Item%20count%20-%2053%20Best%20practices-blue.svg" alt="53 items"/> <img src="https://img.shields.io/badge/%F0%9F%93%85%20Last%20update%20-%206%20days%20ago-green.svg" alt="Last update: 7 days ago"/> <img src="https://img.shields.io/badge/%E2%9C%94%20Updated%20For%20Version%20-%20Node%208.4-brightgreen.svg" alt="Updated for Node v.8.4"/>
 
-<!--- ![Node.js Best Practices](assets/images/banner-1.png) -->
+<!--- ![Node.js Best Practices](../../assets/images/banner-1.png) -->
 
 # Welcome to Node.js Best Practices
 


### PR DESCRIPTION
There were some links that were inside of HTML comments as I assume because they weren't exist

Replace those dead translation links with the original ones.

Apparently, even links in comments are been checked before run/build in Docusaurus