### PR TITLE
variable naming convention with screaming case

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,14 +338,14 @@ const count = 2 // it tries to run 2(), but 2 is not a function
 
 ## ![✔] 3.6 Use naming conventions for variables, constants, functions and classes
 
-**TL;DR:** Use **_lowerCamelCase_** when naming constants, variables and functions and **_UpperCamelCase_** (capital first letter as well) when naming classes, **_SCREAMING_CASE_** when naming global or static variables. This will help you to easily distinguish between plain variables/functions, classes that require instantiation and variables declared at global module scope. Use descriptive names, but try to keep them short
+**TL;DR:** Use **_lowerCamelCase_** when naming constants, variables and functions and **_UpperCamelCase_** (capital first letter as well) when naming classes, **_UPPER_SNAKE_CASE_** when naming global or static variables. This will help you to easily distinguish between plain variables/functions, classes that require instantiation and variables declared at global module scope. Use descriptive names, but try to keep them short
 
 **Otherwise:** JavaScript is the only language in the world that allows invoking a constructor ("Class") directly without instantiating it first. Consequently, Classes and function-constructors are differentiated by starting with UpperCamelCase
 
 ### 3.6 Code Example
 
 ```javascript
-// for global variables names we use the const/let keyword and SCREAMING_CASE
+// for global variables names we use the const/let keyword and UPPER_SNAKE_CASE
 let MUTABLE_GLOBAL = "mutable value"
 const GLOBAL_CONSTANT = "immutable value";
 const CONFIG = {
@@ -354,7 +354,7 @@ const CONFIG = {
 
 // for class name we use UpperCamelCase
 class SomeClassExample {
-  // for static class properties we use SCREAMING_CASE
+  // for static class properties we use UPPER_SNAKE_CASE
   static STATIC_PROPERTY = "value";
 }
 

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ class SomeClassExample {
 function doSomething() {
   // for scoped variable names we use the const/let keyword and lowerCamelCase
   const someConstExample = "immutable value";
-  let someVariableExample = "mutable value";
+  let someMutableExample = "mutable value";
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -352,6 +352,15 @@ const CONFIG = {
   key: "value",
 };
 
+// examples of UPPER_SNAKE_CASE convetion in nodejs/javascript ecosystem
+// in javascript Math.PI module
+const PI = 3.141592653589793;
+
+// https://github.com/nodejs/node/blob/master/lib/internal/http2/core.js
+// in nodejs http2 module
+const HTTP_STATUS_OK = 200;
+const HTTP_STATUS_CREATED = 201;
+
 // for class name we use UpperCamelCase
 class SomeClassExample {
   // for static class properties we use UPPER_SNAKE_CASE

--- a/README.md
+++ b/README.md
@@ -338,24 +338,32 @@ const count = 2 // it tries to run 2(), but 2 is not a function
 
 ## ![✔] 3.6 Use naming conventions for variables, constants, functions and classes
 
-**TL;DR:** Use **_lowerCamelCase_** when naming constants, variables and functions and **_UpperCamelCase_** (capital first letter as well) when naming classes. This will help you to easily distinguish between plain variables/functions, and classes that require instantiation. Use descriptive names, but try to keep them short
+**TL;DR:** Use **_lowerCamelCase_** when naming constants, variables and functions and **_UpperCamelCase_** (capital first letter as well) when naming classes, **_SCREAMING_CASE_** when naming global or static variables. This will help you to easily distinguish between plain variables/functions, classes that require instantiation and variables declared at global module scope. Use descriptive names, but try to keep them short
 
 **Otherwise:** JavaScript is the only language in the world that allows invoking a constructor ("Class") directly without instantiating it first. Consequently, Classes and function-constructors are differentiated by starting with UpperCamelCase
 
 ### 3.6 Code Example
 
 ```javascript
-// for class name we use UpperCamelCase
-class SomeClassExample {}
-
-// for const names we use the const keyword and lowerCamelCase
-const config = {
+// for global variables names we use the const/let keyword and SCREAMING_CASE
+let MUTABLE_GLOBAL = "mutable value"
+const GLOBAL_CONSTANT = "immutable value";
+const CONFIG = {
   key: "value",
 };
 
-// for variables and functions names we use lowerCamelCase
-let someVariableExample = "value";
-function doSomething() {}
+// for class name we use UpperCamelCase
+class SomeClassExample {
+  // for static class properties we use SCREAMING_CASE
+  static STATIC_PROPERTY = "value";
+}
+
+// for functions names we use lowerCamelCase
+function doSomething() {
+  // for scoped variable names we use the const/let keyword and lowerCamelCase
+  const someConstExample = "immutable value";
+  let someVariableExample = "mutable value";
+}
 ```
 
 <br/><br/>

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ const count = 2 // it tries to run 2(), but 2 is not a function
 
 ## ![✔] 3.6 Use naming conventions for variables, constants, functions and classes
 
-**TL;DR:** Use **_lowerCamelCase_** when naming constants, variables and functions and **_UpperCamelCase_** (capital first letter as well) when naming classes, **_UPPER_SNAKE_CASE_** when naming global or static variables. This will help you to easily distinguish between plain variables/functions, classes that require instantiation and variables declared at global module scope. Use descriptive names, but try to keep them short
+**TL;DR:** Use **_lowerCamelCase_** when naming constants, variables and functions, **_UpperCamelCase_** (capital first letter as well) when naming classes and **_UPPER_SNAKE_CASE_** when naming global or static variables. This will help you to easily distinguish between plain variables, functions, classes that require instantiation and variables declared at global module scope. Use descriptive names, but try to keep them short
 
 **Otherwise:** JavaScript is the only language in the world that allows invoking a constructor ("Class") directly without instantiating it first. Consequently, Classes and function-constructors are differentiated by starting with UpperCamelCase
 

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ const CONFIG = {
 // in javascript Math.PI module
 const PI = 3.141592653589793;
 
-// https://github.com/nodejs/node/blob/master/lib/internal/http2/core.js
+// https://github.com/nodejs/node/blob/b9f36062d7b5c5039498e98d2f2c180dca2a7065/lib/internal/http2/core.js#L303
 // in nodejs http2 module
 const HTTP_STATUS_OK = 200;
 const HTTP_STATUS_CREATED = 201;


### PR DESCRIPTION
Update variable naming convention to include `SCREAMING_CASE` for global variables and static class properties

closes: #1043