### PR TITLE
Fix: typo  on 4.2 Include 3 parts in each test name

### DIFF
--- a/sections/testingandquality/3-parts-in-name.md
+++ b/sections/testingandquality/3-parts-in-name.md
@@ -14,7 +14,7 @@ A test report should tell whether the current application revision satisfies the
 
 <br/><br/>
 
-### Code example: a test name that incluces 3 parts
+### Code example: a test name that includes 3 parts
 ```javascript
 //1. unit under test
 describe('Products Service', () => {


### PR DESCRIPTION
Fix: typo on 4.2 Include 3 parts in each test name