### PR TITLE
Delete contributing.md

### DIFF
--- a/.operations/contributing.md
+++ b/.operations/contributing.md
@@ -1,1 +1,0 @@
-Our contribution guide [can be found here](./.operations/CONTRIBUTING.md)


### PR DESCRIPTION
Removing as git will log a warning for the same file name (on case-insensitive filesystem)
```
warning: the following paths have collided (e.g. case-sensitive paths
on a case-insensitive filesystem) and only one from the same
colliding group is in the working tree:

  '.operations/CONTRIBUTING.md'
  '.operations/contributing.md'
```