### PR TITLE
Fix avoid example in curly braces

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,8 @@ function someFunction() {
 }
 
 // Avoid
-function someFunction() {
+function someFunction()
+{
   // code block
 }
 ```


### PR DESCRIPTION
The Do and Don't examples are identical. It seems the avoid one was intended to have the curly brace on a new line. The PR fixes it.