### PR TITLE
Fix 3.3 Start a Codeblock's Curly Braces on the Same Line

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,8 @@ function someFunction() {
 }
 
 // Avoid
-function someFunction() {
+function someFunction() 
+{
   // code block
 }
 ```


### PR DESCRIPTION
The "Do" and "Avoid" functions looked the same