### PR TITLE
Add reference to the 'aaa-comments' ESLint rule

### DIFF
--- a/sections/testingandquality/aaa.md
+++ b/sections/testingandquality/aaa.md
@@ -11,6 +11,7 @@ The 2nd A - Act: Execute the unit under test. Usually 1 line of code
 
 The 3rd A - Assert: Ensure that the received value satisfies the expectation. Usually 1 line of code
 
+This pattern can be enforced with the ESLint rule ['aaa-comments'](https://github.com/MatanYadaev/eslint-plugin-testing/blob/main/docs/rules/aaa-comments.md).
 
 <br/><br/>
 


### PR DESCRIPTION
I've developed an ESLint plugin introducing a rule for ensuring AAA comments. I believe it would be beneficial to include it in this repository.
I'm already using this ESLint plugin internally in my company and it helps a lot, so I just published it publicly.

If this PR will be accepted, I'll submit the same PR to the `javascript-testing-best-practices` repository.

And BTW Yoni, thanks a lot for your amazing work. I'm a big fan of this and your other best practices repositories!